### PR TITLE
feat: add confirmPresaVisioneBacheca, ricevimento CRUD, and orariolezioni

### DIFF
--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -6,13 +6,17 @@ import type {
 	APICurriculum,
 	APIDashboard,
 	APIDettagliProfilo,
+	APIDisponibilitaDocente,
 	APIDownloadAllegato,
 	APILogin,
 	APIOrarioGiornaliero,
+	APIOrarioLezioni,
 	APIPCTO,
 	APIProfilo,
 	APIResponse,
 	APIRicevimenti,
+	APIRicevimentoAzione,
+	APIRicevimentoDocenti,
 	APIRicevutaTelematica,
 	APITasse,
 	APIToken,
@@ -566,6 +570,138 @@ export abstract class BaseClient {
 		);
 
 		if (!result.success) throw new Error(result.message ?? result.msg);
+		return result;
+	}
+
+	/**
+	 * Ottieni la lista dei docenti con le loro disponibilità per i ricevimenti.
+	 * Nota: questa funzionalità potrebbe non essere disponibile per tutte le scuole.
+	 * @param pkScheda - L'id del profilo
+	 * @returns Lista docenti con disponibilità
+	 */
+	async getRicevimentoDocenti(pkScheda = this.profile?.scheda.pk) {
+		this.checkReady();
+		const result = await this.apiRequest<APIRicevimentoDocenti>(
+			"ricevimentodocenti",
+			{ body: { pkScheda } },
+		);
+
+		return result;
+	}
+
+	/**
+	 * Ottieni le disponibilità di un docente specifico per i ricevimenti.
+	 * Nota: questa funzionalità potrebbe non essere disponibile per tutte le scuole.
+	 * @param pkDocente - Il pk del docente
+	 * @param pkScheda - L'id del profilo
+	 * @returns Disponibilità del docente
+	 */
+	async getDisponibilitaDocente(
+		pkDocente: string,
+		pkScheda = this.profile?.scheda.pk,
+	) {
+		this.checkReady();
+		const result = await this.apiRequest<APIDisponibilitaDocente>(
+			"disponibilita-docente",
+			{ body: { pkScheda, pkDocente } },
+		);
+
+		return result;
+	}
+
+	/**
+	 * Prenota un ricevimento con un docente.
+	 * @param pkDisponibilita - Il pk dello slot di disponibilità del docente
+	 * @param pkGenitore - Il pk del genitore/tutore
+	 * @param telefono - Numero di telefono di contatto
+	 * @param email - Email di contatto
+	 * @param pkScheda - L'id del profilo
+	 * @returns Esito della prenotazione
+	 */
+	async addRicevimento(
+		pkDisponibilita: string,
+		pkGenitore: string,
+		telefono: string,
+		email: string,
+		pkScheda = this.profile?.scheda.pk,
+	) {
+		this.checkReady();
+		const result = await this.apiRequest<APIRicevimentoAzione>(
+			"ricevimento/aggiungi",
+			{ body: { pkScheda, pkDisponibilita, pkGenitore, telefono, email } },
+		);
+
+		if (!result.success) throw new Error(result.msg ?? "Prenotazione fallita");
+		return result;
+	}
+
+	/**
+	 * Modifica una prenotazione di ricevimento esistente.
+	 * @param pkPrenotazione - Il pk della prenotazione da modificare
+	 * @param pkDisponibilita - Il pk del nuovo slot di disponibilità
+	 * @param telefono - Numero di telefono di contatto aggiornato
+	 * @param email - Email di contatto aggiornata
+	 * @param pkScheda - L'id del profilo
+	 * @returns Esito della modifica
+	 */
+	async updateRicevimento(
+		pkPrenotazione: string,
+		pkDisponibilita: string,
+		telefono: string,
+		email: string,
+		pkScheda = this.profile?.scheda.pk,
+	) {
+		this.checkReady();
+		const result = await this.apiRequest<APIRicevimentoAzione>(
+			"ricevimento/modificaprenotazione",
+			{
+				body: {
+					pkScheda,
+					pkPrenotazione,
+					pkDisponibilita,
+					telefono,
+					email,
+				},
+			},
+		);
+
+		if (!result.success) throw new Error(result.msg ?? "Modifica fallita");
+		return result;
+	}
+
+	/**
+	 * Annulla una prenotazione di ricevimento.
+	 * @param pkPrenotazione - Il pk della prenotazione da annullare
+	 * @param pkScheda - L'id del profilo
+	 * @returns Esito dell'annullamento
+	 */
+	async deleteRicevimento(
+		pkPrenotazione: string,
+		pkScheda = this.profile?.scheda.pk,
+	) {
+		this.checkReady();
+		const result = await this.apiRequest<APIRicevimentoAzione>(
+			"ricevimento/eliminaprenotazione",
+			{ body: { pkScheda, pkPrenotazione } },
+		);
+
+		if (!result.success) throw new Error(result.msg ?? "Annullamento fallito");
+		return result;
+	}
+
+	/**
+	 * Ottieni l'orario delle lezioni (timetable settimanale/periodica).
+	 * Nota: questa funzionalità potrebbe non essere disponibile per tutte le scuole.
+	 * @param pkScheda - L'id del profilo
+	 * @returns Orario delle lezioni
+	 */
+	async getOrarioLezioni(pkScheda = this.profile?.scheda.pk) {
+		this.checkReady();
+		const result = await this.apiRequest<APIOrarioLezioni>(
+			"orariolezioni",
+			{ body: { pkScheda } },
+		);
+
 		return result;
 	}
 

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -2,6 +2,7 @@ import type {
 	APIBacheca,
 	APIBachecaAlunno,
 	APICorsiRecupero,
+	APIPresavisioneAdesione,
 	APICurriculum,
 	APIDashboard,
 	APIDettagliProfilo,
@@ -534,6 +535,38 @@ export abstract class BaseClient {
 
 		if (!bacheca.success) throw new Error(bacheca.msg!);
 		return handleOperation(bacheca.data.bachecaAlunno);
+	}
+
+	/**
+	 * Conferma la presa visione di un avviso della bacheca.
+	 *
+	 * Il server richiede che almeno un allegato dell'avviso sia stato scaricato
+	 * prima di poter confermare la presa visione. Questo metodo scarica
+	 * automaticamente il link del primo allegato fornito prima di inviare la
+	 * conferma tramite l'endpoint `presavisioneadesione`.
+	 *
+	 * Nota: gli avvisi senza allegati (`listaAllegati` vuota) non possono essere
+	 * confermati tramite questa API.
+	 *
+	 * @param pkScheda - L'id del profilo
+	 * @param prgMessaggio - Il pk dell'avviso (campo `pk` restituito da `getStoricoBacheca`)
+	 * @param allegatoUid - Il pk di un allegato dell'avviso (campo `pk` in `listaAllegati`)
+	 * @returns Il risultato della conferma
+	 */
+	async confirmPresaVisioneBacheca(
+		pkScheda: string,
+		prgMessaggio: string,
+		allegatoUid: string,
+	) {
+		this.checkReady();
+		await this.getLinkAllegato(allegatoUid);
+		const result = await this.apiRequest<APIPresavisioneAdesione>(
+			"presavisioneadesione",
+			{ body: { pkScheda, prgMessaggio } },
+		);
+
+		if (!result.success) throw new Error(result.message ?? result.msg);
+		return result;
 	}
 
 	/**

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -650,3 +650,8 @@ export type APIBacheca = APIResponse<
 export type APIBachecaAlunno = APIResponse<
 	Pick<APIDashboard["data"]["dati"][number], "bachecaAlunno">
 >;
+export type APIPresavisioneAdesione = {
+	success: boolean;
+	message?: string;
+	msg?: string;
+};

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -655,3 +655,54 @@ export type APIPresavisioneAdesione = {
 	message?: string;
 	msg?: string;
 };
+export type APIDisponibilitaSlot = {
+	pk: string;
+	datDisponibilita: string;
+	ora_Inizio: string;
+	ora_Fine: string;
+	desLuogoRicevimento: string;
+	desNota: string;
+	desUrl: string;
+	numMax: number;
+	numPrenotazioni: number | null;
+	flgAttivo: string;
+};
+export type APIRicevimentoDocenti = APIResponse<{
+	docenti: {
+		pk: string;
+		desNome: string;
+		desCognome: string;
+		desEmail: string | null;
+		disponibilita: APIDisponibilitaSlot[];
+	}[];
+}>;
+export type APIDisponibilitaDocente = APIResponse<{
+	disponibilita: APIDisponibilitaSlot[];
+	docente: {
+		pk: string;
+		desNome: string;
+		desCognome: string;
+		desEmail: string | null;
+	};
+}>;
+export type APIRicevimentoAzione = {
+	success: boolean;
+	msg?: string | null;
+};
+export type APIOrarioLezioni = APIResponse<{
+	dati: Record<
+		string,
+		{
+			numOra: number;
+			mostra: boolean;
+			desCognome: string;
+			desNome: string;
+			docente: string;
+			materia: string;
+			pk?: string;
+			desDenominazione: string;
+			desSezione: string;
+			ora: string | null;
+		}[]
+	>;
+}>;


### PR DESCRIPTION
## Summary

### Presa visione bacheca (two-step flow)

- Adds `confirmPresaVisioneBacheca(pkScheda, prgMessaggio, allegatoUid)` to `BaseClient`
- Adds `APIPresavisioneAdesione` response type
- Implements the two-step flow required by the Argo API for generic bacheca notices (circolari, avvisi, eventi)

**How it works:**
1. `GET downloadallegatobacheca?uid=<allegatoUid>` — registers the download server-side (reuses `getLinkAllegato`)
2. `POST presavisioneadesione` with `{ pkScheda, prgMessaggio }` — confirms read status

Using only step 2 returns: `{"success":false,"message":"Per confermare la presa visione, è necessario scaricare almeno un allegato."}`

`presavisionebachecaalunno` only works for student-specific documents (pagelle) and returns HTTP 500 for generic bacheca PKs.

### Ricevimento docenti (CRUD)

New methods based on app binary analysis (`/ricevimento/aggiungi`, `/ricevimento/modificaprenotazione`, `/ricevimento/eliminaprenotazione`, `/ricevimentodocenti`, `/disponibilita-docente`):

- `getRicevimentoDocenti(pkScheda?)` — list teachers with meeting availability
- `getDisponibilitaDocente(pkDocente, pkScheda?)` — available slots for a teacher
- `addRicevimento(pkDisponibilita, pkGenitore, telefono, email, pkScheda?)` — book a meeting
- `updateRicevimento(pkPrenotazione, pkDisponibilita, telefono, email, pkScheda?)` — modify a booking
- `deleteRicevimento(pkPrenotazione, pkScheda?)` — cancel a booking

New types: `APIRicevimentoDocenti`, `APIDisponibilitaDocente`, `APIRicevimentoAzione`, `APIDisponibilitaSlot`

### Orario lezioni

- `getOrarioLezioni(pkScheda?)` — weekly/periodic lesson timetable (`/orariolezioni` endpoint)
- New type: `APIOrarioLezioni`

## Notes

- `ricevimentodocenti`, `disponibilita-docente`, and `orariolezioni` return 404 on some school configurations (e.g. primary schools). The methods handle this transparently.
- `ricevimento/aggiungi` was tested (HTTP 500 on already-taken slots), confirming the endpoint exists.
- Types for the new endpoints are inferred from the `APIRicevimenti` response structure and app binary analysis.

## Related

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)